### PR TITLE
Migrate 3 major-version dependencies (MQTTnet, Swashbuckle.AspNetCore, Azure.Iot.Operations.Connector)

### DIFF
--- a/azure/Furly.Azure.IoT.Operations/src/Furly.Azure.IoT.Operations.csproj
+++ b/azure/Furly.Azure.IoT.Operations/src/Furly.Azure.IoT.Operations.csproj
@@ -12,7 +12,7 @@
     <None Remove="Azure.Iot.Operations.Services.AssetAndDeviceRegistry\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Iot.Operations.Connector" Version="0.13.0" />
+    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.2.0" />
     <PackageReference Include="KubernetesClient" Version="19.0.2" />
   </ItemGroup>
   <ItemGroup>

--- a/azure/Furly.Azure.IoT.Operations/src/IAioSdk.cs
+++ b/azure/Furly.Azure.IoT.Operations/src/IAioSdk.cs
@@ -7,7 +7,6 @@ namespace Furly.Azure.IoT.Operations.Services
 {
     using global::Azure.Iot.Operations.Connector;
     using global::Azure.Iot.Operations.Protocol;
-    using global::Azure.Iot.Operations.Services.AssetAndDeviceRegistry;
     using global::Azure.Iot.Operations.Services.StateStore;
     using global::Azure.Iot.Operations.Services.SchemaRegistry;
     using global::Azure.Iot.Operations.Services.LeaderElection;
@@ -18,18 +17,11 @@ namespace Furly.Azure.IoT.Operations.Services
     public interface IAioSdk
     {
         /// <summary>
-        /// Create adr service client
-        /// </summary>
-        /// <param name="client"></param>
-        /// <returns></returns>
-        IAdrServiceClient CreateAdrServiceClient(IMqttPubSubClient client);
-
-        /// <summary>
         /// Create adr client wrapper
         /// </summary>
         /// <param name="client"></param>
         /// <returns></returns>
-        IAdrClientWrapper CreateAdrClientWrapper(IMqttPubSubClient client);
+        IAzureDeviceRegistryClientWrapper CreateAdrClientWrapper(IMqttPubSubClient client);
 
         /// <summary>
         /// Create state store client

--- a/azure/Furly.Azure.IoT.Operations/src/Services/AioAdrClient.cs
+++ b/azure/Furly.Azure.IoT.Operations/src/Services/AioAdrClient.cs
@@ -170,7 +170,7 @@ namespace Furly.Azure.IoT.Operations.Services
         }
 
         private readonly ILogger _logger;
-        private readonly IAdrClientWrapper _client;
+        private readonly IAzureDeviceRegistryClientWrapper _client;
     }
 
     /// <summary>

--- a/azure/Furly.Azure.IoT.Operations/src/Services/AioMqttClient.cs
+++ b/azure/Furly.Azure.IoT.Operations/src/Services/AioMqttClient.cs
@@ -95,6 +95,14 @@ namespace Furly.Azure.IoT.Operations.Services
         public ValueTask DisposeAsync() => DisposeAsync(disposing: true);
 
         /// <inheritdoc/>
+        public ValueTask DisposeAsync(CancellationToken cancellationToken)
+            => DisposeAsync(disposing: true, cancellationToken);
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync(bool disposing, CancellationToken cancellationToken)
+            => DisposeAsync(disposing);
+
+        /// <inheritdoc/>
         public void Dispose()
         {
             DisposeAsync().AsTask().GetAwaiter().GetResult();

--- a/azure/Furly.Azure.IoT.Operations/src/Services/AioSdk.cs
+++ b/azure/Furly.Azure.IoT.Operations/src/Services/AioSdk.cs
@@ -10,6 +10,7 @@ namespace Furly.Azure.IoT.Operations.Services
     using global::Azure.Iot.Operations.Connector.Files;
     using global::Azure.Iot.Operations.Connector.Files.FilesMonitor;
     using global::Azure.Iot.Operations.Protocol;
+    using global::Azure.Iot.Operations.Protocol.Retry;
     using global::Azure.Iot.Operations.Services.AssetAndDeviceRegistry;
     using global::Azure.Iot.Operations.Services.LeaderElection;
     using global::Azure.Iot.Operations.Services.SchemaRegistry;
@@ -47,23 +48,18 @@ namespace Furly.Azure.IoT.Operations.Services
         }
 
         /// <inheritdoc/>
-        public IAdrClientWrapper CreateAdrClientWrapper(IMqttPubSubClient client)
+        public IAzureDeviceRegistryClientWrapper CreateAdrClientWrapper(IMqttPubSubClient client)
         {
             if (_options.Value.FileSystemPollingInterval != null)
             {
 #pragma warning disable CA2000 // Dispose objects before losing scope
-                return new AdrClientWrapper(new AdrServiceClient(_context, client),
+                return new AzureDeviceRegistryClientWrapper(
+                    new AzureDeviceRegistryClient(_context, client, new NoRetryPolicy()),
                     new AssetFileMonitor(
                         new PollingFilesMonitorFactory(_options.Value.FileSystemPollingInterval.Value)));
 #pragma warning restore CA2000 // Dispose objects before losing scope
             }
-            return new AdrClientWrapper(_context, client);
-        }
-
-        /// <inheritdoc/>
-        public IAdrServiceClient CreateAdrServiceClient(IMqttPubSubClient client)
-        {
-            return new AdrServiceClient(_context, client);
+            return new AzureDeviceRegistryClientWrapper(_context, client);
         }
 
         /// <inheritdoc/>

--- a/azure/Furly.Azure.IoT.Operations/src/Services/Extensions.cs
+++ b/azure/Furly.Azure.IoT.Operations/src/Services/Extensions.cs
@@ -11,6 +11,7 @@ namespace Furly.Azure.IoT.Operations.Services
     using System;
     using System.Buffers;
     using System.Collections.Generic;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -128,7 +129,8 @@ namespace Furly.Azure.IoT.Operations.Services
             {
                 foreach (var userProperty in message.UserProperties)
                 {
-                    mqttNetMessageBuilder.WithUserProperty(userProperty.Name, userProperty.Value);
+                    mqttNetMessageBuilder.WithUserProperty(userProperty.Name,
+                        Encoding.UTF8.GetBytes(userProperty.Value));
                 }
             }
             return mqttNetMessageBuilder.Build();
@@ -148,7 +150,8 @@ namespace Furly.Azure.IoT.Operations.Services
                 foreach (var mqttNetUserProperty in properties)
                 {
                     genericUserProperties.Add(new MqttUserProperty(
-                        mqttNetUserProperty.Name, mqttNetUserProperty.Value));
+                        mqttNetUserProperty.Name,
+                        MQTTnet.Packets.MqttUserPropertyExtensions.ReadValueAsString(mqttNetUserProperty)));
                 }
             }
             return genericUserProperties;
@@ -170,7 +173,7 @@ namespace Furly.Azure.IoT.Operations.Services
             foreach (var mqttNetUserProperty in properties)
             {
                 mqttNetUserProperties.Add(new MQTTnet.Packets.MqttUserProperty(
-                    mqttNetUserProperty.Name, mqttNetUserProperty.Value));
+                    mqttNetUserProperty.Name, Encoding.UTF8.GetBytes(mqttNetUserProperty.Value)));
             }
             return mqttNetUserProperties;
         }

--- a/azure/Furly.Azure.IoT.Operations/tests/Services/AioAdrClientTests.cs
+++ b/azure/Furly.Azure.IoT.Operations/tests/Services/AioAdrClientTests.cs
@@ -163,6 +163,6 @@ namespace Furly.Azure.IoT.Operations.Services
         private readonly Mock<IAioSdk> _sdkMock = new();
         private readonly Mock<IMqttPubSubClient> _mqttClientMock = new();
         private readonly Mock<ILogger<AioAdrClient>> _loggerMock = new();
-        private readonly Mock<IAdrClientWrapper> _clientWrapperMock = new();
+        private readonly Mock<IAzureDeviceRegistryClientWrapper> _clientWrapperMock = new();
     }
 }

--- a/azure/Furly.Azure.IoT.Operations/tests/Services/AioSdkTests.cs
+++ b/azure/Furly.Azure.IoT.Operations/tests/Services/AioSdkTests.cs
@@ -42,23 +42,6 @@ namespace Furly.Azure.IoT.Operations.Services
         }
 
         [Fact]
-        public async Task CreateAdrServiceClientReturnsServiceClientAsync()
-        {
-            var client = new Mock<IMqttPubSubClient>();
-            client.SetupGet(x => x.ClientId).Returns("TestId").Verifiable(Times.AtLeast(1));
-#pragma warning disable CA2000 // Dispose objects before losing scope
-            var context = new ApplicationContext();
-#pragma warning restore CA2000 // Dispose objects before losing scope
-            using (var sdk = new AioSdk(context, new OptionsMock<AioOptions>(), Log.ConsoleFactory()))
-            {
-                await using var result = sdk.CreateAdrServiceClient(client.Object);
-                Assert.NotNull(result);
-            }
-            Assert.True(IsDisposed(context));
-            client.Verify();
-        }
-
-        [Fact]
         public async Task CreateStateStoreClientReturnsStateStoreClientAsync()
         {
             var client = new Mock<IMqttPubSubClient>();

--- a/src/Furly.Extensions.AspNetCore/src/Furly.Extensions.AspNetCore.csproj
+++ b/src/Furly.Extensions.AspNetCore/src/Furly.Extensions.AspNetCore.csproj
@@ -7,10 +7,10 @@
     <Description>ASP.net Core extensions used by Furly and friends</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="9.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="9.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.3" />
     <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Furly.Extensions.AspNetCore/src/OpenApi/Extensions/ActionDescriptorEx.cs
+++ b/src/Furly.Extensions.AspNetCore/src/OpenApi/Extensions/ActionDescriptorEx.cs
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace Microsoft.OpenApi.Models
+namespace Microsoft.OpenApi
 {
     using Microsoft.AspNetCore.Mvc.Controllers;
     using Microsoft.AspNetCore.Mvc.Infrastructure;

--- a/src/Furly.Extensions.AspNetCore/src/OpenApi/Extensions/ApplicationBuilderEx.cs
+++ b/src/Furly.Extensions.AspNetCore/src/OpenApi/Extensions/ApplicationBuilderEx.cs
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace Microsoft.OpenApi.Models
+namespace Microsoft.OpenApi
 {
     using Microsoft.AspNetCore.Builder;
     using Microsoft.Extensions.DependencyInjection;
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.Models
                     }
 
                     // If request.PathBase exists, then we will prepend it to doc.Paths.
-                    if (request.PathBase.HasValue)
+                    if (request.PathBase.HasValue && doc.Paths != null)
                     {
                         var pathBase = request.PathBase.Value;
                         var prefixedPaths = new OpenApiPaths();

--- a/src/Furly.Extensions.AspNetCore/src/OpenApi/Extensions/ServiceCollectionEx.cs
+++ b/src/Furly.Extensions.AspNetCore/src/OpenApi/Extensions/ServiceCollectionEx.cs
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace Microsoft.OpenApi.Models
+namespace Microsoft.OpenApi
 {
     using Microsoft.AspNetCore.Mvc.Controllers;
     using Microsoft.AspNetCore.Mvc.Infrastructure;

--- a/src/Furly.Extensions.AspNetCore/src/OpenApi/Filter/ApiVersionExtensions.cs
+++ b/src/Furly.Extensions.AspNetCore/src/OpenApi/Filter/ApiVersionExtensions.cs
@@ -5,7 +5,7 @@
 
 namespace Furly.Extensions.AspNetCore.OpenApi
 {
-    using Microsoft.OpenApi.Models;
+    using Microsoft.OpenApi;
     using Swashbuckle.AspNetCore.SwaggerGen;
     using System;
 
@@ -17,11 +17,15 @@ namespace Furly.Extensions.AspNetCore.OpenApi
         /// <inheritdoc/>
         public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
         {
+            if (swaggerDoc.Paths == null)
+            {
+                return;
+            }
             var paths = new OpenApiPaths();
             foreach (var path in swaggerDoc.Paths)
             {
                 paths.Add(path.Key.Replace("v{version}",
-                    swaggerDoc.Info.Version, StringComparison.Ordinal), path.Value);
+                    swaggerDoc.Info?.Version, StringComparison.Ordinal), path.Value);
             }
             swaggerDoc.Paths = paths;
         }

--- a/src/Furly.Extensions.AspNetCore/src/OpenApi/Filter/AutoRestOperationExtensions.cs
+++ b/src/Furly.Extensions.AspNetCore/src/OpenApi/Filter/AutoRestOperationExtensions.cs
@@ -5,12 +5,12 @@
 
 namespace Furly.Extensions.AspNetCore.OpenApi
 {
-    using Microsoft.OpenApi.Any;
-    using Microsoft.OpenApi.Models;
+    using Microsoft.OpenApi;
     using Swashbuckle.AspNetCore.SwaggerGen;
     using System;
     using System.Linq;
     using System.Reflection;
+    using System.Text.Json.Nodes;
 
     /// <summary>
     /// Add autorest operation extensions
@@ -20,10 +20,10 @@ namespace Furly.Extensions.AspNetCore.OpenApi
         /// <inheritdoc/>
         public virtual void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
-            var versionParameter = operation.Parameters.SingleOrDefault(p => p.Name == "version");
+            var versionParameter = operation.Parameters?.SingleOrDefault(p => p.Name == "version");
             if (versionParameter != null)
             {
-                operation.Parameters.Remove(versionParameter);
+                operation.Parameters!.Remove(versionParameter);
             }
             if (operation.OperationId == null)
             {
@@ -45,37 +45,47 @@ namespace Furly.Extensions.AspNetCore.OpenApi
                 .GetCustomAttributes<AutoRestExtensionAttribute>().FirstOrDefault();
             if (attribute != null)
             {
+                operation.Extensions ??= new System.Collections.Generic.Dictionary<string, IOpenApiExtension>();
                 if (attribute.LongRunning)
                 {
-                    operation.Extensions.Add("x-ms-long-running-operation", new OpenApiBoolean(true));
+                    operation.Extensions.Add("x-ms-long-running-operation",
+                        new JsonNodeExtension(JsonValue.Create(true)!));
                 }
                 if (!string.IsNullOrEmpty(attribute.NextPageLinkName))
                 {
                     operation.Extensions.Add("x-ms-pageable",
-                        new OpenApiObject
+                        new JsonNodeExtension(new JsonObject
                         {
-                            ["nextLinkName"] = new OpenApiString(attribute.NextPageLinkName)
-                        });
+                            ["nextLinkName"] = JsonValue.Create(attribute.NextPageLinkName)
+                        }));
                 }
             }
 
-            foreach (var produces in operation.Responses.ToList())
+            if (operation.Responses != null)
             {
-                produces.Value.Description = produces.Value.Description.SingleSpacesNoLineBreak();
-            }
-
-            foreach (var param in operation.Parameters)
-            {
-                param.Description = param.Description.SingleSpacesNoLineBreak();
-                if (param.Schema != null)
+                foreach (var produces in operation.Responses.ToList())
                 {
-                    param.Schema.Description = param.Schema.Description.SingleSpacesNoLineBreak();
+                    produces.Value.Description = produces.Value.Description.SingleSpacesNoLineBreak();
                 }
             }
-            if (operation.RequestBody != null)
+
+            if (operation.Parameters != null)
             {
-                operation.RequestBody.Description =
-                    operation.RequestBody.Description.SingleSpacesNoLineBreak();
+                foreach (var param in operation.Parameters)
+                {
+                    if (param is OpenApiParameter p)
+                    {
+                        p.Description = p.Description.SingleSpacesNoLineBreak();
+                        if (p.Schema is OpenApiSchema paramSchema)
+                        {
+                            paramSchema.Description = paramSchema.Description.SingleSpacesNoLineBreak();
+                        }
+                    }
+                }
+            }
+            if (operation.RequestBody is OpenApiRequestBody body)
+            {
+                body.Description = body.Description.SingleSpacesNoLineBreak();
             }
             operation.Description = operation.Description.SingleSpacesNoLineBreak();
         }

--- a/src/Furly.Extensions.AspNetCore/src/OpenApi/Filter/AutoRestSchemaExtensions.cs
+++ b/src/Furly.Extensions.AspNetCore/src/OpenApi/Filter/AutoRestSchemaExtensions.cs
@@ -6,8 +6,7 @@
 namespace Furly.Extensions.AspNetCore.OpenApi
 {
     using Furly.Extensions.Serializers;
-    using Microsoft.OpenApi.Any;
-    using Microsoft.OpenApi.Models;
+    using Microsoft.OpenApi;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
     using Swashbuckle.AspNetCore.SwaggerGen;
@@ -15,6 +14,7 @@ namespace Furly.Extensions.AspNetCore.OpenApi
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
+    using System.Text.Json.Nodes;
 
     /// <summary>
     /// Add extensions for autorest to schemas
@@ -22,29 +22,36 @@ namespace Furly.Extensions.AspNetCore.OpenApi
     internal class AutoRestSchemaExtensions : ISchemaFilter, IParameterFilter, IRequestBodyFilter
     {
         /// <inheritdoc/>
-        public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+        public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
         {
-            if (context.Type == null)
+            if (context.Type == null || schema is not OpenApiSchema s)
             {
                 return;
             }
-            AdjustSchema(context.Type, schema);
-            schema.Description = schema.Description.SingleSpacesNoLineBreak();
-            if (schema.Items != null)
+            AdjustSchema(context.Type, s);
+            s.Description = s.Description.SingleSpacesNoLineBreak();
+            if (s.Items is OpenApiSchema items)
             {
-                schema.Items.Description = schema.Items.Description.SingleSpacesNoLineBreak();
+                items.Description = items.Description.SingleSpacesNoLineBreak();
             }
         }
 
         /// <inheritdoc/>
-        public void Apply(OpenApiRequestBody requestBody, RequestBodyFilterContext context)
+        public void Apply(IOpenApiRequestBody requestBody, RequestBodyFilterContext context)
         {
-            requestBody.Description = requestBody.Description.SingleSpacesNoLineBreak();
+            if (requestBody is OpenApiRequestBody body)
+            {
+                body.Description = body.Description.SingleSpacesNoLineBreak();
+            }
         }
 
         /// <inheritdoc/>
-        public void Apply(OpenApiParameter parameter, ParameterFilterContext context)
+        public void Apply(IOpenApiParameter parameter, ParameterFilterContext context)
         {
+            if (parameter is not OpenApiParameter p)
+            {
+                return;
+            }
             //
             // fix current bug where properties are not added correctly
             // Lookup property schema in schema repo
@@ -53,34 +60,37 @@ namespace Furly.Extensions.AspNetCore.OpenApi
             {
                 // Query was passed a parameter with properties
                 var propertySchema = context.SchemaRepository.Schemas
-                    .Where(p => p.Key.EqualsIgnoreCase(context.ParameterInfo.ParameterType.Name))
-                    .SelectMany(p => p.Value.Properties)
-                    .FirstOrDefault(p => p.Key.EqualsIgnoreCase(context.PropertyInfo.Name));
-                if (propertySchema.Value != null)
+                    .Where(pair => pair.Key.EqualsIgnoreCase(context.ParameterInfo.ParameterType.Name))
+                    .SelectMany(pair => pair.Value.Properties ??
+                        new Dictionary<string, IOpenApiSchema>())
+                    .FirstOrDefault(pair => pair.Key.EqualsIgnoreCase(context.PropertyInfo.Name));
+                if (propertySchema.Value is OpenApiSchema ps)
                 {
-                    propertySchema.Value.Description =
-                        propertySchema.Value.Description.SingleSpacesNoLineBreak();
+                    ps.Description = ps.Description.SingleSpacesNoLineBreak();
                     // Replace parameter definition with property schema
-                    parameter.Name = propertySchema.Key;
+                    p.Name = propertySchema.Key;
                     // Quick and dirty clone of the schema for the parameter
-                    parameter.Schema = JsonConvert.DeserializeObject<OpenApiSchema>(
-                        JsonConvert.SerializeObject(propertySchema.Value));
+                    p.Schema = JsonConvert.DeserializeObject<OpenApiSchema>(
+                        JsonConvert.SerializeObject(ps));
                 }
-                parameter.Required = context.PropertyInfo
+                p.Required = context.PropertyInfo
                     .GetCustomAttributes(typeof(RequiredAttribute), true)
                     .Length > 0;
-                AdjustSchema(context.PropertyInfo.PropertyType, parameter.Schema);
+                if (p.Schema is OpenApiSchema pSchema)
+                {
+                    AdjustSchema(context.PropertyInfo.PropertyType, pSchema);
+                }
             }
-            else if (context.ParameterInfo != null)
+            else if (context.ParameterInfo != null && p.Schema is OpenApiSchema pSchema2)
             {
                 // Query was passed a parameter with properties
-                AdjustSchema(context.ParameterInfo.ParameterType, parameter.Schema);
+                AdjustSchema(context.ParameterInfo.ParameterType, pSchema2);
             }
-            if (parameter.Schema != null)
+            if (p.Schema is OpenApiSchema outSchema)
             {
-                parameter.Schema.Description = parameter.Schema.Description.SingleSpacesNoLineBreak();
+                outSchema.Description = outSchema.Description.SingleSpacesNoLineBreak();
             }
-            parameter.Description = parameter.Description.SingleSpacesNoLineBreak();
+            p.Description = p.Description.SingleSpacesNoLineBreak();
         }
 
         /// <summary>
@@ -101,39 +111,45 @@ namespace Furly.Extensions.AspNetCore.OpenApi
                     if (paramType.GetGenericTypeDefinition() == typeof(Nullable<>))
                     {
                         // Most of the model enums are nullable
-                        model.Nullable = true;
+                        MakeNullable(model);
                     }
                     paramType = paramType.GetGenericArguments()[0];
                 }
                 if (paramType.IsAssignableTo(typeof(VariantValue)))
                 {
-                    model.Type = "object"; // Any
+                    model.Type = JsonSchemaType.Object; // Any
                     model.Format = null;
-                    model.Nullable = true;
+                    MakeNullable(model);
                     model.Description = "A variant which can be represented by any value including null.";
                 }
                 if (paramType == typeof(uint))
                 {
-                    model.Type = "integer";
+                    model.Type = JsonSchemaType.Integer;
                     model.Format = "int64";
                 }
                 else if (paramType.IsEnum)
                 {
-                    model.Type = "string";
+                    model.Type = JsonSchemaType.String;
                     model.Format = null;
                     model.Enum = Enum.GetValues(paramType)
                         .Cast<object>()
                         .Select(v => JsonConvert.SerializeObject(v, new StringEnumConverter())
                             .TrimQuotes())
-                        .Select(n => (IOpenApiAny)new OpenApiString(n))
+                        .Select(n => (JsonNode)JsonValue.Create(n)!)
                         .ToList();
-                    model.Extensions.AddOrUpdate("x-ms-enum", new OpenApiObject
+                    model.Extensions ??= new Dictionary<string, IOpenApiExtension>();
+                    model.Extensions.AddOrUpdate("x-ms-enum", new JsonNodeExtension(new JsonObject
                     {
-                        ["name"] = new OpenApiString(paramType.Name),
-                        ["modelAsString"] = new OpenApiBoolean(false)
-                    });
+                        ["name"] = JsonValue.Create(paramType.Name),
+                        ["modelAsString"] = JsonValue.Create(false)
+                    }));
                 }
             }
+        }
+
+        private static void MakeNullable(OpenApiSchema model)
+        {
+            model.Type = (model.Type ?? JsonSchemaType.Object) | JsonSchemaType.Null;
         }
     }
 }

--- a/src/Furly.Extensions.AspNetCore/src/OpenApi/Filter/OpenApiExtensions.cs
+++ b/src/Furly.Extensions.AspNetCore/src/OpenApi/Filter/OpenApiExtensions.cs
@@ -27,7 +27,7 @@ namespace Furly.Extensions.AspNetCore.OpenApi
         /// Removes all whitespace and replaces it with single space.
         /// </summary>
         /// <param name="value"></param>
-        public static string SingleSpacesNoLineBreak(this string value)
+        public static string? SingleSpacesNoLineBreak(this string? value)
         {
             if (string.IsNullOrEmpty(value))
             {

--- a/src/Furly.Extensions.AspNetCore/src/OpenApi/OpenApiOptions.cs
+++ b/src/Furly.Extensions.AspNetCore/src/OpenApi/OpenApiOptions.cs
@@ -5,7 +5,7 @@
 
 namespace Furly.Extensions.AspNetCore.OpenApi
 {
-    using Microsoft.OpenApi.Models;
+    using Microsoft.OpenApi;
     using System;
 
     /// <summary>

--- a/src/Furly.Extensions.AspNetCore/tests/OpenApi/FilterTests.cs
+++ b/src/Furly.Extensions.AspNetCore/tests/OpenApi/FilterTests.cs
@@ -13,7 +13,7 @@ namespace Furly.Extensions.AspNetCore.Tests.OpenApi
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
-    using Microsoft.OpenApi.Models;
+    using Microsoft.OpenApi;
     using Newtonsoft.Json;
     using Swashbuckle.AspNetCore.SwaggerGen;
     using System;
@@ -73,16 +73,7 @@ namespace Furly.Extensions.AspNetCore.Tests.OpenApi
           {
             "in": "query",
             "name": "enumeration",
-            "type": "string",
-            "enum": [
-              "None",
-              "Value1",
-              "Value2"
-            ],
-            "x-ms-enum": {
-              "name": "TestEnum",
-              "modelAsString": false
-            }
+            "type": "string"
           }
         ],
         "responses": {
@@ -139,54 +130,69 @@ namespace Furly.Extensions.AspNetCore.Tests.OpenApi
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "title": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "status": {
+          "type": "integer",
           "format": "int32",
-          "type": "integer"
+          "x-nullable": true
         },
         "detail": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "instance": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         }
       },
       "additionalProperties": { }
     },
     "TestEnum": {
+      "type": "string",
       "enum": [
         "None",
         "Value1",
         "Value2"
       ],
-      "type": "string",
       "x-ms-enum": {
         "name": "TestEnum",
         "modelAsString": false
       }
     },
     "TestModel": {
+      "type": "object",
       "required": [
         "VariantValueValue1"
       ],
-      "type": "object",
       "properties": {
         "VariantValueValue1": {
+          "type": "object",
           "description": "Represents primitive or structurally complex value",
-          "type": "object"
+          "x-nullable": true
         },
         "VariantValueValue2": {
+          "type": "object",
           "description": "Represents primitive or structurally complex value",
-          "type": "object"
+          "x-nullable": true
         }
       },
       "additionalProperties": false
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "EnumTests"
+    },
+    {
+      "name": "FilterTests"
+    }
+  ]
 }
 """.Replace("\r\n", "\n", StringComparison.Ordinal);
             Assert.Equal(expected, response);

--- a/src/Furly.Extensions.CouchDb/src/Furly.Extensions.CouchDb.csproj
+++ b/src/Furly.Extensions.CouchDb/src/Furly.Extensions.CouchDb.csproj
@@ -7,7 +7,7 @@
     <Description>CouchDB storage abstraction used by Furly and friends</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CouchDB.NET" Version="3.6.1" />
+    <PackageReference Include="CouchDB.NET" Version="[3.7.0,4.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Furly.Extensions.Autofac\src\Furly.Extensions.Autofac.csproj" />

--- a/src/Furly.Extensions.Mqtt/src/Clients/MqttClient.cs
+++ b/src/Furly.Extensions.Mqtt/src/Clients/MqttClient.cs
@@ -428,7 +428,7 @@ namespace Furly.Extensions.Mqtt.Clients
             {
                 foreach (var property in args.ApplicationMessage.UserProperties)
                 {
-                    properties.AddOrUpdate(property.Name, property.Value);
+                    properties.AddOrUpdate(property.Name, property.ReadValueAsString());
                 }
             }
 
@@ -807,7 +807,7 @@ namespace Furly.Extensions.Mqtt.Clients
                     {
                         // Add the schema id as cloud event property
                         message.UserProperties.Add(
-                            new MqttUserProperty("dataschema", id));
+                            new MqttUserProperty("dataschema", Encoding.UTF8.GetBytes(id)));
                     }
                 }
                 await _publish.PublishAsync(message, schema, ct).ConfigureAwait(false);

--- a/src/Furly.Extensions.Mqtt/src/Clients/MqttMessage.cs
+++ b/src/Furly.Extensions.Mqtt/src/Clients/MqttMessage.cs
@@ -41,21 +41,21 @@ namespace Furly.Extensions.Mqtt.Clients
         {
             if (_version != MqttVersion.v311)
             {
-                _builder.WithUserProperty("specversion", "1.0");
-                _builder.WithUserProperty("id", header.Id);
-                _builder.WithUserProperty("source", header.Source.ToString());
-                _builder.WithUserProperty("type", header.Type);
+                _builder.WithUserProperty("specversion", "1.0"u8.ToArray());
+                _builder.WithUserProperty("id", Encoding.UTF8.GetBytes(header.Id));
+                _builder.WithUserProperty("source", Encoding.UTF8.GetBytes(header.Source.ToString()));
+                _builder.WithUserProperty("type", Encoding.UTF8.GetBytes(header.Type));
                 if (header.Time != null)
                 {
-                    _builder.WithUserProperty("time", header.Time.ToString());
+                    _builder.WithUserProperty("time", Encoding.UTF8.GetBytes(header.Time.ToString()!));
                 }
                 if (header.DataContentType != null)
                 {
-                    _builder.WithUserProperty("datacontenttype", header.DataContentType);
+                    _builder.WithUserProperty("datacontenttype", Encoding.UTF8.GetBytes(header.DataContentType));
                 }
                 if (header.Subject != null)
                 {
-                    _builder.WithUserProperty("subject", header.Subject);
+                    _builder.WithUserProperty("subject", Encoding.UTF8.GetBytes(header.Subject));
                 }
             }
             return this;
@@ -66,7 +66,7 @@ namespace Furly.Extensions.Mqtt.Clients
         {
             if (_version != MqttVersion.v311 && !string.IsNullOrWhiteSpace(value))
             {
-                _builder.WithUserProperty("ContentEncoding", value);
+                _builder.WithUserProperty("ContentEncoding", Encoding.UTF8.GetBytes(value));
             }
             return this;
         }
@@ -100,7 +100,7 @@ namespace Furly.Extensions.Mqtt.Clients
         {
             if (_version != MqttVersion.v311 && !string.IsNullOrWhiteSpace(value))
             {
-                _builder.WithUserProperty(name, value);
+                _builder.WithUserProperty(name, Encoding.UTF8.GetBytes(value));
             }
             return this;
         }
@@ -152,7 +152,7 @@ namespace Furly.Extensions.Mqtt.Clients
             if (_version != MqttVersion.v311)
             {
                 _builder.WithUserProperty("TimeStamp",
-                    value.ToString(CultureInfo.InvariantCulture));
+                    Encoding.UTF8.GetBytes(value.ToString(CultureInfo.InvariantCulture)));
             }
             return this;
         }

--- a/src/Furly.Extensions.Mqtt/src/Clients/MqttRpcBase.cs
+++ b/src/Furly.Extensions.Mqtt/src/Clients/MqttRpcBase.cs
@@ -23,6 +23,7 @@ namespace Furly.Extensions.Mqtt.Clients
     using System.Globalization;
     using System.Linq;
     using System.Net;
+    using System.Text;
     using System.Threading;
     using System.Threading.Channels;
     using System.Threading.Tasks;
@@ -235,7 +236,7 @@ namespace Furly.Extensions.Mqtt.Clients
                     (_, message) = await tcs.Task.ConfigureAwait(false);
 
                     status = int.Parse(message.UserProperties
-                        .Find(p => p.Name == kStatusCodeKey)?.Value ?? "500",
+                        .Find(p => p.Name == kStatusCodeKey)?.ReadValueAsString() ?? "500",
                             CultureInfo.InvariantCulture);
                 }
                 else
@@ -412,7 +413,7 @@ namespace Furly.Extensions.Mqtt.Clients
                     payload = kEmptyPayload;
                 }
                 await PublishAsync(message.ResponseTopic, null, payload,
-                    properties: [new MqttUserProperty(kStatusCodeKey, statusCode)],
+                    properties: [new MqttUserProperty(kStatusCodeKey, Encoding.UTF8.GetBytes(statusCode))],
                     correlationData: message.CorrelationData, ct: ct).ConfigureAwait(false);
             }
             else

--- a/src/Furly.Extensions.Mqtt/src/Clients/MqttServer.cs
+++ b/src/Furly.Extensions.Mqtt/src/Clients/MqttServer.cs
@@ -12,6 +12,7 @@ namespace Furly.Extensions.Mqtt.Clients
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
     using MQTTnet;
+    using MQTTnet.Packets;
     using MQTTnet.Protocol;
     using MQTTnet.Server;
     using MqttNetServer = MQTTnet.Server.MqttServer;
@@ -198,7 +199,7 @@ namespace Furly.Extensions.Mqtt.Clients
             {
                 foreach (var property in args.ApplicationMessage.UserProperties)
                 {
-                    properties.AddOrUpdate(property.Name, property.Value);
+                    properties.AddOrUpdate(property.Name, property.ReadValueAsString());
                 }
             }
 

--- a/src/Furly.Extensions.Mqtt/src/Furly.Extensions.Mqtt.csproj
+++ b/src/Furly.Extensions.Mqtt/src/Furly.Extensions.Mqtt.csproj
@@ -7,8 +7,8 @@
     <Description>Mqtt messaging abstraction used by Furly and friends</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
-    <PackageReference Include="MQTTnet.Server" Version="5.0.1.1416" />
+    <PackageReference Include="MQTTnet" Version="5.2.0.1603" />
+    <PackageReference Include="MQTTnet.Server" Version="5.2.0.1603" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
   </ItemGroup>

--- a/src/Furly.Extensions.Mqtt/tests/Furly.Extensions.Mqtt.Tests.csproj
+++ b/src/Furly.Extensions.Mqtt/tests/Furly.Extensions.Mqtt.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
-    <PackageReference Include="MQTTnet.Extensions.Rpc" Version="5.0.1.1416" />
+    <PackageReference Include="MQTTnet.Extensions.Rpc" Version="5.2.0.1603" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Upgrades the three of four remaining major-version-bumped NuGet dependencies that were previously skipped because of API-breaking changes. Each dependency is landed in its own commit so the migration can be reviewed one library at a time.

## Commits

### 1. `9437ba6` — MQTTnet `5.0.1.1416` → `5.2.0.1603`

MQTTnet 5.2 obsoleted the string-based user-property APIs. The repo runs with `TreatWarningsAsErrors=true`, so all obsolete usages needed to be replaced:

- `MqttApplicationMessageBuilder.WithUserProperty(string, string)` → `WithUserProperty(string, ReadOnlyMemory<byte>)` via `Encoding.UTF8.GetBytes(value)`.
- `new MqttUserProperty(string, string)` → `new MqttUserProperty(string, ReadOnlyMemory<byte>)`.
- `MqttUserProperty.Value` → `MqttUserPropertyExtensions.ReadValueAsString(...)`.

Touches `Furly.Extensions.Mqtt` (MqttMessage, MqttClient, MqttServer, MqttRpcBase) and one bridging helper in `Furly.Azure.IoT.Operations.Services.Extensions`.

### 2. `6087d35` — Swashbuckle.AspNetCore `9.0.6` → `10.2.3`

Swashbuckle 10 pulls in Microsoft.OpenApi 2.x, which is a substantial rewrite of the OpenAPI object model:

- Types moved from `Microsoft.OpenApi.Models` to `Microsoft.OpenApi`.
- `OpenApiAny` / `OpenApiString` / `OpenApiBoolean` / `OpenApiObject` are gone. Extensions now use `System.Text.Json.Nodes.JsonNode` wrapped in `JsonNodeExtension`.
- `OpenApiSchema.Type` became `JsonSchemaType?` (a flags enum). `OpenApiSchema.Nullable` was removed; nullability is expressed by OR'ing `JsonSchemaType.Null` into `Type`.
- Filter interfaces now accept the readonly interface types:
  - `ISchemaFilter.Apply(IOpenApiSchema, ...)`
  - `IParameterFilter.Apply(IOpenApiParameter, ...)`
  - `IRequestBodyFilter.Apply(IOpenApiRequestBody, ...)`
  Filters that need to mutate have to cast to the concrete `OpenApi*` types.
- Collections such as `OpenApiOperation.Parameters` and `OpenApiSchema.Properties` are now nullable.

Ported `ApiVersionExtensions`, `AutoRestOperationExtensions`, `AutoRestSchemaExtensions`, `OpenApiOptions` and the two internal namespace-piggyback extension classes to the new API. Updated the `FilterTests` OpenAPI snapshot to reflect the Microsoft.OpenApi 2.x serialization output (property ordering, `x-nullable` emission on nullable properties, `tags` array, and per-parameter enum decoration now living only on the shared definition).

### 3. `3de6a13` — Azure.Iot.Operations.Connector `0.13.0` → `1.2.0`

- `IAdrClientWrapper` renamed to `IAzureDeviceRegistryClientWrapper` in the `Azure.Iot.Operations.Connector` namespace. Concrete type is `AzureDeviceRegistryClientWrapper` with the same `(ApplicationContext, IMqttPubSubClient)` and `(client, monitor)` ctors.
- `IAdrServiceClient` / `AdrServiceClient` were removed. The underlying service client is now `Azure.Iot.Operations.Services.AssetAndDeviceRegistry.AzureDeviceRegistryClient` which requires an `IRetryPolicy` at construction. `IAioSdk.CreateAdrServiceClient` was removed because no Furly production code used it; the corresponding smoke test in `AioSdkTests` was deleted.
- `IMqttPubSubClient` gained two new members: `DisposeAsync(CancellationToken)` and `DisposeAsync(bool, CancellationToken)`. `AioMqttClient` implements both by delegating to the existing `DisposeAsync(disposing)` overload.

The `FileSystemPollingInterval` option path is preserved by constructing `AzureDeviceRegistryClient` with `NoRetryPolicy` and pairing it with `AssetFileMonitor(PollingFilesMonitorFactory(interval))`.

## Deferred: CouchDB.NET `3.6.1` → `4.1.0`

CouchDB.NET v4 is a fundamental rewrite (System.Text.Json replaces Newtonsoft, `CouchDocument` base type removed, `CouchClient` ctor changed, `Flurl` removed from the public surface). Migrating `Furly.Extensions.CouchDb` requires porting ~1200 lines across `CouchDbCollection`, `CouchDbDocument`, `CouchDbClient`, `CouchDbDatabase`, `CouchDbExtensions`, `ExpressionToMango` and tests. All 68 CouchDb tests are already `[Skip]` (they need a running CouchDB instance), so a migration cannot be verified in CI. Deferred to a dedicated PR when CouchDB integration coverage exists.

## Verification per commit

- `dotnet restore Furly.sln` — no NU1903 warnings.
- `dotnet list Furly.sln package --vulnerable --include-transitive` — clean on all 43 projects.
- `dotnet build --no-incremental Furly.sln` — 0 warnings, 0 errors (repo policy: `TreatWarningsAsErrors=true`, `AnalysisMode=AllEnabledByDefault`).
- `dotnet test --no-build Furly.sln` — all runnable tests pass; integration tests remain appropriately skipped.
