### PR TITLE
Fix forwarded-headers trust model (security)

### DIFF
--- a/src/Furly.Extensions.AspNetCore/src/EnvironmentVariable.cs
+++ b/src/Furly.Extensions.AspNetCore/src/EnvironmentVariable.cs
@@ -17,6 +17,25 @@ namespace Furly.Extensions.AspNetCore
         /// <summary> Limit number of entries in the forwarded headers. </summary>
         public const string FORWARDEDHEADERSFORWARDLIMIT =
             "ASPNETCORE_FORWARDEDHEADERS_FORWARDLIMIT";
+        /// <summary>
+        /// Comma/semicolon separated list of trusted proxy IP addresses
+        /// whose forwarded headers are honored.
+        /// </summary>
+        public const string FORWARDEDHEADERSKNOWNPROXIES =
+            "ASPNETCORE_FORWARDEDHEADERS_KNOWNPROXIES";
+        /// <summary>
+        /// Comma/semicolon separated list of trusted proxy networks in CIDR
+        /// notation (e.g. 10.0.0.0/8) whose forwarded headers are honored.
+        /// </summary>
+        public const string FORWARDEDHEADERSKNOWNNETWORKS =
+            "ASPNETCORE_FORWARDEDHEADERS_KNOWNNETWORKS";
+        /// <summary>
+        /// Opt-in to trust forwarded headers from any remote address. This
+        /// disables known-proxy validation and should only be used when the
+        /// app is not directly reachable by untrusted clients.
+        /// </summary>
+        public const string FORWARDEDHEADERSTRUSTALLPROXIES =
+            "ASPNETCORE_FORWARDEDHEADERS_TRUSTALLPROXIES";
         /// <summary> Redirect port </summary>
         public const string HTTPSREDIRECTPORT =
             "ASPNETCORE_HTTPSREDIRECTPORT";

--- a/src/Furly.Extensions.AspNetCore/src/Hosting/Runtime/HeadersConfig.cs
+++ b/src/Furly.Extensions.AspNetCore/src/Hosting/Runtime/HeadersConfig.cs
@@ -10,6 +10,10 @@ namespace Furly.Extensions.AspNetCore.Hosting.Runtime
     using Microsoft.AspNetCore.HttpOverrides;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Options;
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using IPNetwork = System.Net.IPNetwork;
 
     /// <summary>
     /// Forwarded headers processing configuration.
@@ -42,17 +46,88 @@ namespace Furly.Extensions.AspNetCore.Hosting.Runtime
                     options.ForwardLimit);
             options.ForwardedHeaders = ForwardedHeaders.XForwardedFor |
                 ForwardedHeaders.XForwardedProto;
-            // Only loopback proxies are allowed by default.
-            // Clear that restriction because forwarders are enabled by explicit
-            // configuration.
-            options.KnownIPNetworks.Clear();
-            options.KnownProxies.Clear();
+
+            // Register explicitly trusted proxies / networks so that forwarded
+            // headers are only honored when they originate from them. This keeps
+            // ASP.NET Core's known-proxy validation active (the secure default).
+            var restricted = AddKnownProxies(options);
+            restricted |= AddKnownNetworks(options);
+
+            // Only disable known-proxy validation (i.e. trust forwarded headers
+            // from any remote address) when the operator explicitly opts in and
+            // has not already narrowed trust via the lists above. Without this
+            // opt-in the framework default (loopback only) is preserved, which
+            // prevents arbitrary clients from spoofing X-Forwarded-For /
+            // X-Forwarded-Proto.
+            if (!restricted && GetBoolOrDefault(
+                EnvironmentVariable.FORWARDEDHEADERSTRUSTALLPROXIES))
+            {
+                options.KnownIPNetworks.Clear();
+                options.KnownProxies.Clear();
+            }
         }
 
         /// <inheritdoc/>
         public void Configure(ForwardedHeadersOptions options)
         {
             Configure(Options.DefaultName, options);
+        }
+
+        /// <summary>
+        /// Add configured trusted proxy addresses to the known proxies.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns>True if at least one proxy was added.</returns>
+        private bool AddKnownProxies(ForwardedHeadersOptions options)
+        {
+            var added = false;
+            foreach (var entry in Split(GetStringOrDefault(
+                EnvironmentVariable.FORWARDEDHEADERSKNOWNPROXIES)))
+            {
+                if (IPAddress.TryParse(entry, out var address))
+                {
+                    options.KnownProxies.Add(address);
+                    added = true;
+                }
+            }
+            return added;
+        }
+
+        /// <summary>
+        /// Add configured trusted proxy networks to the known networks.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns>True if at least one network was added.</returns>
+        private bool AddKnownNetworks(ForwardedHeadersOptions options)
+        {
+            var added = false;
+            foreach (var entry in Split(GetStringOrDefault(
+                EnvironmentVariable.FORWARDEDHEADERSKNOWNNETWORKS)))
+            {
+                if (IPNetwork.TryParse(entry, out var network))
+                {
+                    options.KnownIPNetworks.Add(network);
+                    added = true;
+                }
+            }
+            return added;
+        }
+
+        /// <summary>
+        /// Split a comma/semicolon/space separated list into entries.
+        /// </summary>
+        /// <param name="value"></param>
+        private static IEnumerable<string> Split(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                yield break;
+            }
+            foreach (var part in value.Split([',', ';', ' '],
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                yield return part;
+            }
         }
     }
 }

--- a/src/Furly.Extensions.AspNetCore/tests/Hosting/HeadersConfigTests.cs
+++ b/src/Furly.Extensions.AspNetCore/tests/Hosting/HeadersConfigTests.cs
@@ -1,0 +1,99 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Furly.Extensions.AspNetCore.Tests.Hosting
+{
+    using Furly.Extensions.AspNetCore.Hosting.Runtime;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.HttpOverrides;
+    using Microsoft.Extensions.Configuration;
+    using System.Collections.Generic;
+    using System.Net;
+    using Xunit;
+    using IPNetwork = System.Net.IPNetwork;
+
+    public class HeadersConfigTests
+    {
+        [Fact]
+        public void DefaultDoesNotDisableKnownProxyValidation()
+        {
+            var options = new ForwardedHeadersOptions();
+            var defaultProxies = options.KnownProxies.Count;
+            var defaultNetworks = options.KnownIPNetworks.Count;
+
+            CreateConfig().Configure(options);
+
+            // The loopback defaults must be preserved so forwarded headers are
+            // only trusted from known proxies (secure default).
+            Assert.Equal(defaultProxies, options.KnownProxies.Count);
+            Assert.Equal(defaultNetworks, options.KnownIPNetworks.Count);
+            Assert.True(options.KnownProxies.Count > 0 || options.KnownIPNetworks.Count > 0);
+            Assert.Equal(ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
+                options.ForwardedHeaders);
+        }
+
+        [Fact]
+        public void ConfiguredKnownProxiesAreAdded()
+        {
+            var options = new ForwardedHeadersOptions();
+            CreateConfig(new Dictionary<string, string?>
+            {
+                [EnvironmentVariable.FORWARDEDHEADERSKNOWNPROXIES] = "10.1.2.3, 2001:db8::1"
+            }).Configure(options);
+
+            Assert.Contains(IPAddress.Parse("10.1.2.3"), options.KnownProxies);
+            Assert.Contains(IPAddress.Parse("2001:db8::1"), options.KnownProxies);
+        }
+
+        [Fact]
+        public void ConfiguredKnownNetworksAreAdded()
+        {
+            var options = new ForwardedHeadersOptions();
+            CreateConfig(new Dictionary<string, string?>
+            {
+                [EnvironmentVariable.FORWARDEDHEADERSKNOWNNETWORKS] = "10.0.0.0/8;192.168.0.0/16"
+            }).Configure(options);
+
+            Assert.Contains(IPNetwork.Parse("10.0.0.0/8"), options.KnownIPNetworks);
+            Assert.Contains(IPNetwork.Parse("192.168.0.0/16"), options.KnownIPNetworks);
+        }
+
+        [Fact]
+        public void TrustAllOptInClearsKnownProxiesAndNetworks()
+        {
+            var options = new ForwardedHeadersOptions();
+            CreateConfig(new Dictionary<string, string?>
+            {
+                [EnvironmentVariable.FORWARDEDHEADERSTRUSTALLPROXIES] = "true"
+            }).Configure(options);
+
+            Assert.Empty(options.KnownProxies);
+            Assert.Empty(options.KnownIPNetworks);
+        }
+
+        [Fact]
+        public void TrustAllOptInIsIgnoredWhenProxiesConfigured()
+        {
+            var options = new ForwardedHeadersOptions();
+            CreateConfig(new Dictionary<string, string?>
+            {
+                [EnvironmentVariable.FORWARDEDHEADERSTRUSTALLPROXIES] = "true",
+                [EnvironmentVariable.FORWARDEDHEADERSKNOWNPROXIES] = "10.1.2.3"
+            }).Configure(options);
+
+            // Explicit trust must win over the trust-all opt-in.
+            Assert.Contains(IPAddress.Parse("10.1.2.3"), options.KnownProxies);
+            Assert.NotEmpty(options.KnownProxies);
+        }
+
+        private static HeadersConfig CreateConfig(IDictionary<string, string?>? values = null)
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(values ?? new Dictionary<string, string?>())
+                .Build();
+            return new HeadersConfig(configuration);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the MEDIUM finding from the security review (PR #13): the forwarded-headers configuration disabled ASP.NET Core's trusted-proxy validation.

## Problem

`HeadersConfig.Configure` cleared **both** `KnownIPNetworks` and `KnownProxies` whenever forwarded-header processing was enabled:

```csharp
options.KnownIPNetworks.Clear();
options.KnownProxies.Clear();
```

ASP.NET Core's `ForwardedHeadersMiddleware` only runs its known-proxy check when at least one known network/proxy is registered. With both empty, the middleware applies `X-Forwarded-For` / `X-Forwarded-Proto` from **any** remote client. When the app is directly reachable this allows:

- **Source-IP spoofing** (`X-Forwarded-For`) → `RemoteIpAddress` becomes attacker-controlled, defeating IP allow-lists / rate-limit exemptions and forging audit logs.
- **Scheme spoofing** (`X-Forwarded-Proto: https`) → the app believes plaintext requests arrived over TLS, undermining HTTPS-redirect logic and `Secure`-cookie enforcement.

## Fix

Preserve the framework's secure default (trust loopback only) and let operators register their actual reverse proxy / load balancer:

| Environment variable | Effect |
|---|---|
| `ASPNETCORE_FORWARDEDHEADERS_KNOWNPROXIES` | Comma/semicolon list of trusted proxy IPs → added to `KnownProxies` |
| `ASPNETCORE_FORWARDEDHEADERS_KNOWNNETWORKS` | Comma/semicolon list of trusted proxy networks (CIDR) → added to `KnownIPNetworks` |
| `ASPNETCORE_FORWARDEDHEADERS_TRUSTALLPROXIES` | Explicit opt-in to the old trust-all behavior, honored only when no known proxies/networks are configured |

## Behavior change

Consumers that enabled forwarding and relied on the implicit trust-all behavior now trust only loopback unless they register their proxies (recommended) or set `ASPNETCORE_FORWARDEDHEADERS_TRUSTALLPROXIES=true`. This aligns Furly with ASP.NET Core's secure default.

## Tests

Adds `HeadersConfigTests` covering: default (validation preserved), configured known proxies, configured known networks, trust-all opt-in (clears lists), and precedence (explicit proxies win over trust-all).

Verification: `dotnet build --no-incremental Furly.sln` 0 warnings / 0 errors; full `dotnet test` suite passes.
