### PR TITLE
Fix MQTT memory/handle leak: dispose orphaned session on reconnect

### DIFF
--- a/src/Furly.Extensions.Mqtt/src/Clients/MqttClient.cs
+++ b/src/Furly.Extensions.Mqtt/src/Clients/MqttClient.cs
@@ -376,11 +376,43 @@ namespace Furly.Extensions.Mqtt.Clients
                     _connection = Task.WhenAll(_sessions
                         .Select(c => c.ConnectAsync(GetSessionClientOptions(), _cts.Token)));
                     _logger.SessionRecreated(session.ClientId ?? "unknown");
+
+                    // Dispose the now-orphaned session so its underlying mqtt
+                    // client, event handler subscriptions, meter and
+                    // synchronization primitives are released instead of
+                    // accumulating on every reconnect. Disposal runs off this
+                    // callback to avoid re-entering the session while it tears
+                    // itself down.
+                    DisposeOrphanedSession(session);
                     return Task.CompletedTask;
                 }
             }
             _logger.SessionNotRecreated(session.ClientId ?? "unknown");
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Dispose a session that was replaced after its mqtt session was lost.
+        /// Runs disposal on a background task so it does not block or re-enter
+        /// the session's own SessionLost callback.
+        /// </summary>
+        /// <param name="session"></param>
+        private void DisposeOrphanedSession(MqttSession session)
+        {
+            var sessionId = session.ClientId ?? "unknown";
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await session.DisposeAsync().AsTask()
+                        .WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+                }
+                catch (ObjectDisposedException) { }
+                catch (Exception ex)
+                {
+                    _logger.OrphanedSessionDisposeFailed(ex, sessionId);
+                }
+            });
         }
 
         /// <summary>
@@ -928,5 +960,9 @@ namespace Furly.Extensions.Mqtt.Clients
         [LoggerMessage(EventId = EventClass + 15, Level = LogLevel.Information,
             Message = "Closed mqtt client {ClientId} ...")]
         public static partial void ClientClosed(this ILogger logger, string clientId);
+
+        [LoggerMessage(EventId = EventClass + 16, Level = LogLevel.Error,
+            Message = "Mqtt client failed to dispose orphaned mqtt session {SessionId}.")]
+        public static partial void OrphanedSessionDisposeFailed(this ILogger logger, Exception ex, string sessionId);
     }
 }


### PR DESCRIPTION
## Problem

MQTT publishers leak memory and OS handles on every broker reconnect. Diagnosed while investigating [Azure/Industrial-IoT#2365](https://github.com/Azure/Industrial-IoT/issues/2365) (increasing memory consumption).

`MqttClient.HandleSessionClosedAsync` (wired to `MqttSession.SessionLost`) replaces a lost session with a fresh one via `CreateSession()` but **never disposes the old `MqttSession`**:

```csharp
_sessions[i] = CreateSession();   // new MqttSession = new MQTTnet client + Meter + CTS + semaphores + ack thread
// old session is abandoned, never disposed
```

The orphaned session's `DisposeAsync` (which unsubscribes the MQTTnet event handlers and disposes its meter/CTS/semaphores) never runs, so each reconnect permanently leaks the whole session object graph.

## Evidence

Reproduced against a live OPC Publisher (Furly 1.2.6) with repeated MQTT broker restarts; `dotnet-gcdump` heap diffs show **linear** per-reconnect growth:

| Type | base | 8 flaps | 18 flaps |
|---|---|---|---|
| `Func<MqttClientDisconnectedEventArgs,Task>` | 5 | 45 | 95 |
| `Func<MqttClientConnectedEventArgs,Task>` | 2 | 18 | 38 |
| `CancellationTokenSource` | 78 | 102 | 132 |
| `SemaphoreSlim` | 42 | 66 | 96 |
| `AutoResetEvent` | 7 | 15 | 19 |

Process handle count plateaued ~74 above baseline (CTS/SemaphoreSlim/AutoResetEvent each hold an OS handle).

## Fix

Dispose the orphaned session after swapping in the replacement, off the `SessionLost` callback (via `Task.Run`) to avoid re-entering/deadlocking the session while it tears itself down. `DisposeAsync` is bounded to 30s (same pattern as `MqttClient.DisposeAsync`).

## Testing

- `dotnet build` of `Furly.Extensions.Mqtt` and its test project: 0 warnings / 0 errors.
- A deterministic `SessionLost` integration test isn't practical with the in-process `MqttServerFixture` (session expiry is broker-timing dependent and the event is internal); validated via the Industrial-IoT live heap-diff repro above (growth eliminated once the orphaned session is disposed).
