### PR TITLE
Update NuGet dependencies to latest

### DIFF
--- a/azure/Furly.Azure.CosmosDb/tests/Furly.Azure.CosmosDb.Tests.csproj
+++ b/azure/Furly.Azure.CosmosDb/tests/Furly.Azure.CosmosDb.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit" Version="2.9.3">
       <TreatAsUsed>true</TreatAsUsed>

--- a/azure/Furly.Azure.EventHubs/tests/Furly.Azure.EventHubs.Tests.csproj
+++ b/azure/Furly.Azure.EventHubs/tests/Furly.Azure.EventHubs.Tests.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit" Version="2.9.3">
       <TreatAsUsed>true</TreatAsUsed>

--- a/azure/Furly.Azure.IoT.Edge/tests/Furly.Azure.IoT.Edge.Tests.csproj
+++ b/azure/Furly.Azure.IoT.Edge/tests/Furly.Azure.IoT.Edge.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit" Version="2.9.3">
       <TreatAsUsed>true</TreatAsUsed>

--- a/azure/Furly.Azure.IoT.Operations/tests/Furly.Azure.IoT.Operations.Tests.csproj
+++ b/azure/Furly.Azure.IoT.Operations/tests/Furly.Azure.IoT.Operations.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="[4.20.2]" />
     <PackageReference Include="Neovolve.Logging.Xunit" Version="6.3.0" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />

--- a/azure/Furly.Azure.IoT/tests/Furly.Azure.IoT.Tests.csproj
+++ b/azure/Furly.Azure.IoT/tests/Furly.Azure.IoT.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit" Version="2.9.3">
       <TreatAsUsed>true</TreatAsUsed>

--- a/azure/Furly.Azure.KeyVault/tests/Furly.Azure.KeyVault.Tests.csproj
+++ b/azure/Furly.Azure.KeyVault/tests/Furly.Azure.KeyVault.Tests.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>net10.0</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq" Version="8.0.0" />
+    <PackageReference Include="Autofac.Extras.Moq" Version="8.0.1" />
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="[4.20.2]" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/azure/Furly.Azure/tests/Furly.Azure.Tests.csproj
+++ b/azure/Furly.Azure/tests/Furly.Azure.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit" Version="2.9.3">
       <TreatAsUsed>true</TreatAsUsed>

--- a/common.props
+++ b/common.props
@@ -28,8 +28,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup Condition="$(NO_GIT) == ''">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All"/>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" PrivateAssets="All"/>
   </ItemGroup>
   <PropertyGroup>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/src/Furly.Extensions.AspNetCore/tests/Furly.Extensions.AspNetCore.Tests.csproj
+++ b/src/Furly.Extensions.AspNetCore/tests/Furly.Extensions.AspNetCore.Tests.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Furly.Extensions.Autofac/src/Furly.Extensions.Autofac.csproj
+++ b/src/Furly.Extensions.Autofac/src/Furly.Extensions.Autofac.csproj
@@ -7,10 +7,10 @@
     <Description>Common utilities used by Furly and friends</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.2" />
   </ItemGroup>
 </Project>

--- a/src/Furly.Extensions.Autofac/tests/Furly.Extensions.Autofac.Tests.csproj
+++ b/src/Furly.Extensions.Autofac/tests/Furly.Extensions.Autofac.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Furly.Extensions.CouchDb/tests/Furly.Extensions.CouchDb.Tests.csproj
+++ b/src/Furly.Extensions.CouchDb/tests/Furly.Extensions.CouchDb.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Furly.Extensions.Dapr/tests/Furly.Extensions.Dapr.Tests.csproj
+++ b/src/Furly.Extensions.Dapr/tests/Furly.Extensions.Dapr.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/Furly.Extensions.Json/src/Furly.Extensions.Json.csproj
+++ b/src/Furly.Extensions.Json/src/Furly.Extensions.Json.csproj
@@ -7,8 +7,8 @@
     <Description>System.Text.Json based Json serializer used by Furly and friends</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Furly.Extensions.Abstractions\src\Furly.Extensions.Abstractions.csproj" />

--- a/src/Furly.Extensions.Json/tests/Furly.Extensions.Json.Tests.csproj
+++ b/src/Furly.Extensions.Json/tests/Furly.Extensions.Json.Tests.csproj
@@ -7,7 +7,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Furly.Extensions.Kafka/tests/Furly.Extensions.Kafka.Tests.csproj
+++ b/src/Furly.Extensions.Kafka/tests/Furly.Extensions.Kafka.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/Furly.Extensions.LiteDb/tests/Furly.Extensions.LiteDb.Tests.csproj
+++ b/src/Furly.Extensions.LiteDb/tests/Furly.Extensions.LiteDb.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Furly.Extensions.MessagePack/src/Furly.Extensions.MessagePack.csproj
+++ b/src/Furly.Extensions.MessagePack/src/Furly.Extensions.MessagePack.csproj
@@ -7,9 +7,9 @@
     <Description>Message Pack serializer used by Furly and friends</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="3.1.7" />
-    <PackageReference Include="Autofac" Version="9.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="MessagePack" Version="3.1.8" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Furly.Extensions.MessagePack/tests/Furly.Extensions.MessagePack.Tests.csproj
+++ b/src/Furly.Extensions.MessagePack/tests/Furly.Extensions.MessagePack.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Furly.Extensions.Mqtt/src/Furly.Extensions.Mqtt.csproj
+++ b/src/Furly.Extensions.Mqtt/src/Furly.Extensions.Mqtt.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="MQTTnet" Version="5.2.0.1603" />
     <PackageReference Include="MQTTnet.Server" Version="5.2.0.1603" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Furly.Extensions.Autofac\src\Furly.Extensions.Autofac.csproj" />

--- a/src/Furly.Extensions.Mqtt/tests/Furly.Extensions.Mqtt.Tests.csproj
+++ b/src/Furly.Extensions.Mqtt/tests/Furly.Extensions.Mqtt.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
     <PackageReference Include="MQTTnet.Extensions.Rpc" Version="5.2.0.1603" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />

--- a/src/Furly.Extensions.Newtonsoft/src/Furly.Extensions.Newtonsoft.csproj
+++ b/src/Furly.Extensions.Newtonsoft/src/Furly.Extensions.Newtonsoft.csproj
@@ -7,9 +7,9 @@
     <Description>Newtonsoft Json.net based serializer used by Furly and friends</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Autofac" Version="9.3.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Furly.Extensions.Newtonsoft/tests/Furly.Extensions.Newtonsoft.Tests.csproj
+++ b/src/Furly.Extensions.Newtonsoft/tests/Furly.Extensions.Newtonsoft.Tests.csproj
@@ -7,7 +7,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Furly.Extensions/src/Furly.Extensions.csproj
+++ b/src/Furly.Extensions/src/Furly.Extensions.csproj
@@ -7,10 +7,10 @@
     <Description>Common utilities used by Furly and friends</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Autofac" Version="9.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Furly.Extensions.Abstractions\src\Furly.Extensions.Abstractions.csproj" />

--- a/src/Furly.Extensions/tests/Furly.Extensions.Tests.csproj
+++ b/src/Furly.Extensions/tests/Furly.Extensions.Tests.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="[4.20.2]" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tunnel/Furly.Tunnel.AspNetCore/tests/Furly.Tunnel.AspNetCore.Tests.csproj
+++ b/tunnel/Furly.Tunnel.AspNetCore/tests/Furly.Tunnel.AspNetCore.Tests.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3">
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>

--- a/tunnel/Furly.Tunnel/src/Furly.Tunnel.csproj
+++ b/tunnel/Furly.Tunnel/src/Furly.Tunnel.csproj
@@ -7,7 +7,7 @@
     <Description>Http Tunnel Core</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.ExceptionSummarization" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.ExceptionSummarization" Version="10.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Furly.Extensions\src\Furly.Extensions.csproj" />

--- a/tunnel/Furly.Tunnel/tests/Furly.Tunnel.Tests.csproj
+++ b/tunnel/Furly.Tunnel/tests/Furly.Tunnel.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="[4.20.2]" />
     <PackageReference Include="xunit" Version="2.9.3">
       <TreatAsUsed>true</TreatAsUsed>


### PR DESCRIPTION
Bumps all **unpinned** NuGet packages to their latest stable versions on nuget.org.

| Package | From | To |
|---|---|---|
| Autofac | 9.3.0 | 9.3.1 |
| Autofac.Extensions.DependencyInjection | 11.0.1 | 11.0.2 |
| Autofac.Extras.Moq | 8.0.0 | 8.0.1 |
| MessagePack | 3.1.7 | 3.1.8 |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.9 | 10.0.10 |
| Microsoft.Extensions.* | 10.0.9 | 10.0.10 |
| Microsoft.Extensions.Diagnostics.ExceptionSummarization | 10.7.0 | 10.8.0 |
| Microsoft.NET.Test.Sdk | 18.7.0 | 18.8.1 |
| Microsoft.SourceLink.GitHub | 10.0.102 | 10.0.301 |
| Nerdbank.GitVersioning | 3.9.50 | 3.10.91 |
| System.IdentityModel.Tokens.Jwt | 8.19.1 | 8.19.2 |

## Intentionally left pinned

These use `[...]` version syntax on purpose and are **not** changed:

- `CouchDB.NET` `[3.7.0,4.0.0)` — 4.x is a breaking rewrite; pinned to major 3.
- `FluentAssertions` `[7.2.0]` — 8.x license change.
- `LiteDB` `[5.0.17]`, `Moq` `[4.20.2]`, `Xunit.Combinatorial` `[1.6.24]`.

## Verification

- `dotnet restore` — no NU1903 warnings.
- `dotnet list Furly.sln package --vulnerable --include-transitive` — clean on all 43 projects.
- `dotnet build --no-incremental Furly.sln` — 0 warnings, 0 errors.
- `dotnet test --no-build Furly.sln` — all runnable tests pass.
